### PR TITLE
EXPERIMENT: Add Other Renditions section to footer

### DIFF
--- a/MobyDickNav/index.html
+++ b/MobyDickNav/index.html
@@ -85,6 +85,31 @@
     <div property="publisher" typeof="Organization">
       Publisher: <span property="name">Harper &amp; Row</span>
     </div>
+
+    <h4>Other Renditions of Moby-Dick:</h4>
+    <ul><!-- with love from https://en.wikipedia.org/wiki/Moby-Dick#Editions -->
+      <li property="workExample" typeof="Book">
+        Melville, H. <i property="name">The Whale</i>.
+        London: <span property="publisher" typeof="Person">
+          <span property="name">Richard Bentley</span></span>, 1851 3 vols.
+        (viii, 312; iv, 303; iv, 328 pp.)
+        Published <span property="datePublished" content="1851-10-18">October 18, 1851</span>.
+      </li>
+      <li property="workExample" typeof="Book">
+        Melville, H., <span property="name"><i>Moby-Dick; or, The Whale</i>: An Authoritative Text, Reviews and Letters by Melville, Analogues and Sources, Criticism. A Norton Critical Edition.</span>
+        Edited by
+        <span property="Editor" typeof="Person"><span property="name">Harrison Hayford</span></span>
+        and
+        <span property="Editor" typeof="Person"><span property="name">Hershel Parker</span></span>.
+        New York:
+        <span property="Publisher" typeof="Organization">
+          <span property="name">W.W. Norton</span>
+        </span>,
+        <span property="datePublished">1967</span>.
+        <a href="/wiki/International_Standard_Book_Number" title="International Standard Book Number">ISBN</a>
+        <a href="/wiki/Special:BookSources/039309670X" title="Special:BookSources/039309670X" property="isbn">039309670X</a>
+      </li>
+    </ul>
   </footer>
   <!-- these should be considered polyfill/shim status scripts -->
   <script src="../book.js"></script>


### PR DESCRIPTION
Way more information than one would probably encode
in most Web Publications, but if a publisher were
tracking previous versions the User Agent could
benefit from the found relationships and data to
offer the user annotation re-anchoring, links to
purchasing paper copies, etc.

Somewhat deliberately excessive. :grin: Also totally orthogonal value-add (i.e. you don't need any of this to use/display/enjoy the publication).