### PR TITLE
Moby-Dick audiobook

### DIFF
--- a/MobyDickAudiobook/index.html
+++ b/MobyDickAudiobook/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html 📖 lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>Moby-Dick</title>
+  <meta name="description" content="Project Gutenberg edition of Moby-Dick">
+
+  <meta name="theme-color" content="#fff">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <main>
+    <nav role="doc-toc">
+      <ol>
+        <li>
+          <a type="audio/mp3" href="mobydick_000_melville.mp3">Chapter 000: Etymology and Extracts</a>
+          read by Stewart Wills
+          <time>00:29:13</time>
+        </li>
+        <li>
+          <a type="audio/mp3" href="http://www.archive.org/download/moby_dick_librivox/mobydick_001_002_melville.mp3" title="external audio file (not offline'd)">🔗Chapter 001-002</a>
+          read by Stewart Wills
+          <time>00:23:56</time>
+        </li>
+      </ol>
+    </nav>
+    <footer>
+      Audio provided by <a href="https://librivox.org/moby-dick-by-herman-melville">LibreVox</a>
+    </footer>
+  </main>
+
+  <!-- these should be considered polyfill/shim status scripts -->
+  <script src="../book.js" defer async></script>
+  <!-- these shims are because book.js uses a Web Component (pub-bar.html)
+       ...and uses .prepend() and append() DOM4 methods -->
+  <script src="../dom4.js" defer async></script>
+  <script src="../webcomponents-lite.js" defer async></script>
+  <!-- end shims -->
+</body>
+</html>

--- a/book.js
+++ b/book.js
@@ -25,22 +25,28 @@ function registerServiceWorker() {
     });
   }
 }
-
 function fauxFramePrimaryResources() {
   console.log('faux framing');
   var spine = document.querySelectorAll("nav[role='doc-toc'] a");
-  // start by caching the Table of Contents
-  var manifestArray = ['./'];
-  for (var spineItem of spine) {
-    manifestArray.push(spineItem.href)
-  }
 
-  // Use hidden iframes to "force" browser to request all the things...
-  manifestArray.forEach((item) => {
-    let iframe = document.createElement('iframe');
-    iframe.src = item;
-    iframe.style.display = 'none';
-    document.body.append(iframe);
+  // start by caching the Table of Contents
+  caches.open('web-publication').then((cache) => {
+    for (var resource of spine) {
+      // undeclared type, so assume it's HTML + dependencies
+      if (resource.type === '') {
+        // Use hidden iframes to "force" browser to request all the things...
+        let iframe = document.createElement('iframe');
+        iframe.src = resource.href;
+        iframe.style.display = 'none';
+        document.body.append(iframe);
+        console.log('iframed', resource.href);
+      } else {
+        console.log('fetching', resource.href);
+        // it's got a specific type, so let's just cache it
+        cache.add(resource.href)
+          .then(() => console.log('successfully cached', resource.href));
+      }
+    }
   });
 }
 


### PR DESCRIPTION
Thanks [LibriVox](https://librivox.org/moby-dick-by-herman-melville)!

There are two items referenced in the Table of Contents. The first is a local (included) `.mp3` file. The second uses a the librivox.org URL to the next `.mp3` file (Chapter 1-2).

I tweaked the caching/faux-framing system to deal with non-HTML files (via `<a type="">`). If it's set to *anything*, the system now directly caches the file rather than "faux framing."

Caveat: the included `.mp3` file is 27 mb...it'll take a while to offline, so...
   - there's not (yet?!) any progress reporting wrt to offlining
   - there are likely cache limitations depending on the test environment

Some options for an implementer:
 - do a HEAD (or similar) check to get the resources `Content-Length` (etc) to judge space needed
 - show progress of "offlinification", so the reader knows how much of the publication they have offline
 - BONUS: (perhaps) provide a mechanism for downloading only certain primary resources (perhaps not even in sequence).

Thoughts welcome!